### PR TITLE
don't 'use Dancer2' and remove 'use Moo::Role'

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,3 +12,6 @@ main_module = lib/Dancer2/Plugin/REST.pm
 -remove=Covenant
 authority = cpan:SUKRIA
 NextVersion::Semantic.format=%d.%02d
+
+[Prereqs]
+Dancer2 = 0.149000_01

--- a/lib/Dancer2/Plugin/REST.pm
+++ b/lib/Dancer2/Plugin/REST.pm
@@ -6,13 +6,8 @@ use warnings;
 
 use Carp 'croak';
 
-use Dancer2 0.149000_01;
 use Dancer2::Plugin;
 use Class::Load qw/ try_load_class /;
-
-use Moo::Role;
-
-with 'Dancer2::Plugin';
 
 # [todo] - add XML support
 my $content_types = {


### PR DESCRIPTION
Fixes to make plugin work with new P2 architecture.