### PR TITLE
Set serializer only on the newly created dancer response object, not on app

### DIFF
--- a/lib/Dancer2/Plugin/REST.pm
+++ b/lib/Dancer2/Plugin/REST.pm
@@ -44,14 +44,14 @@ register prepare_serializer_for_format => sub {
                 return $dsl->send_error("unsupported format requested: " . $format, 404);
             }
 
-            $dsl->set(serializer => $serializer);
+            my $ct = $content_types->{$format} || $dsl->setting('content_type');
+            my $built = $dsl->app->_build_serializer_engine($serializer);
+
             $dsl->app->set_response( Dancer2::Core::Response->new(
                 %{ $dsl->app->response },
-                serializer => $dsl->set('serializer'),
+                serializer => $built,
+                content_type => $ct,
             ) );
-
-            my $ct = $content_types->{$format} || $dsl->setting('content_type');
-            $dsl->content_type($ct);
         }
     );
 };

--- a/t/06_tcp_server.t
+++ b/t/06_tcp_server.t
@@ -4,7 +4,7 @@ use warnings;
 use Plack::Test;
 use HTTP::Request::Common qw(GET POST PUT DELETE);
 
-use Test::More tests => 1;
+use Test::More tests => 3;
 
 { package Webservice;  
 
@@ -16,14 +16,26 @@ use Test::More tests => 1;
     get '/:something.:format' => sub {
         { hello => 'world' };
     };
+
+    get '/serializer' => sub {
+        ref(app->setting('serializer'))||'none';
+    }
 }
 
 my $app = Dancer2->runner->psgi_app;
 
 test_psgi $app, sub {
     my $cb = shift;
-    my $res = $cb->( GET "/foo.json", 'Content-Type' => 'application/json' );
+    my $res;
+
+    $res = $cb->( GET "/serializer", 'Content-Type' => 'text/plain' );
+    is $res->content => 'none';
+
+    $res = $cb->( GET "/foo.json", 'Content-Type' => 'application/json' );
     is $res->content => '{"hello":"world"}';
+
+    $res = $cb->( GET "/serializer", 'Content-Type' => 'text/plain' );
+    is $res->content => 'none';
 };
 
 


### PR DESCRIPTION
More information can be seen on the actual change commit message, but to summarize, we found some apps that were mixing REST endpoints and non-rest endpoints (no format defined as param nor capture) would end up trying to use the default app serizlier and breaking (eg. running an html string through the serializer and erroring).

The patches in this pull request work on our case, but other than checking explicitly for the global app serializer, I failed to get a better test.

My Dancer skills aren't great, so I think it's worth reviewing closely in case I missed relevant bits, backward compatibility issues, etc. An alternate solution proposed by Sawyer was moving the before hook to be an after hook, and doing the serialization directly, but I ran into some more issues that way.

Please poke me for clarification!
